### PR TITLE
Исправлено сохранение статистики задач коммуникаций

### DIFF
--- a/api/src/communications/communications.service.ts
+++ b/api/src/communications/communications.service.ts
@@ -225,7 +225,7 @@ export class CommunicationsService {
       audienceSnapshot: payload.audienceSnapshot ?? { code: audienceCode },
       payload: { ...(payload.payload ?? {}), text },
       timezone: payload.timezone ?? null,
-      stats: payload.stats ?? null,
+      stats: payload.stats ? (payload.stats as Prisma.InputJsonValue) : Prisma.JsonNull,
     });
   }
 
@@ -257,7 +257,7 @@ export class CommunicationsService {
       payload: { ...(payload.payload ?? {}), text },
       media: imageUrl ? { imageUrl } : payload.media ?? null,
       timezone: payload.timezone ?? null,
-      stats: payload.stats ?? null,
+      stats: payload.stats ? (payload.stats as Prisma.InputJsonValue) : Prisma.JsonNull,
     });
   }
 
@@ -309,7 +309,7 @@ export class CommunicationsService {
       failedAt: null,
       payload: (original.payload as Prisma.InputJsonValue) ?? null,
       filters: (original.filters as Prisma.InputJsonValue) ?? null,
-      stats: null,
+      stats: Prisma.JsonNull,
       media: (original.media as Prisma.InputJsonValue) ?? null,
       timezone: original.timezone,
       archivedAt: null,
@@ -386,7 +386,7 @@ export class CommunicationsService {
 
   private normalizeStats(stats?: Record<string, any> | null) {
     if (!stats) {
-      return { statsJson: null, totalRecipients: 0, sentCount: 0, failedCount: 0 };
+      return { statsJson: Prisma.JsonNull, totalRecipients: 0, sentCount: 0, failedCount: 0 };
     }
     const totalRecipients = this.toNumber(stats.totalRecipients ?? stats.total ?? 0);
     const sentCount = this.toNumber(stats.sent ?? stats.delivered ?? 0);


### PR DESCRIPTION
## Summary
- корректно сохраняем пустую статистику задач как Prisma.JsonNull
- устраняем ошибки типизации при дублировании и создании задач коммуникаций

## Testing
- pnpm -C api typecheck *(падает из-за существующих ошибок в других модулях)*

------
https://chatgpt.com/codex/tasks/task_e_68db4ae21f8883248cba619ed1f744a2