### PR TITLE
Drop legacy voucher Prisma models

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -467,6 +467,8 @@ Response 200:
 
 Промокоды управляются через портал мерчанта. Основные операции:
 
+> Legacy ваучеры больше не поддерживаются: таблицы `Voucher*` удалены, внешних интеграций и отчётов на них не осталось.
+
 - `GET /portal/promocodes?status=ACTIVE|ARCHIVE` — список с метриками.
 - `POST /portal/promocodes/issue` — создание промокода (см. `PortalPromoCodePayload`).
 - `PUT /portal/promocodes/:promoCodeId` — обновление.

--- a/api/prisma/migrations/20250915100000_drop_voucher_tables/migration.sql
+++ b/api/prisma/migrations/20250915100000_drop_voucher_tables/migration.sql
@@ -1,0 +1,8 @@
+-- DropTable
+DROP TABLE "public"."VoucherUsage";
+
+-- DropTable
+DROP TABLE "public"."VoucherCode";
+
+-- DropTable
+DROP TABLE "public"."Voucher";

--- a/api/prisma/schema-additions.prisma
+++ b/api/prisma/schema-additions.prisma
@@ -11,14 +11,6 @@
 //  tags             String[]
 //  deletedAt        DateTime?
 
-// Добавить в модель Voucher:
-//  status           String    @default("ACTIVE")
-//  quantity         Int       @default(1)
-//  remainingQuantity Int      @default(1)
-//  maxUsesPerCustomer Int?
-//  maxTotalUses     Int?
-//  minPurchaseAmount Int?
-
 // Добавить в модель Subscription:
 //  autoRenew        Boolean   @default(true)
 //  lastPaymentId    String?
@@ -46,10 +38,6 @@
 
 // Добавить в модель CustomerSegment:
 //  type             String    @default("DYNAMIC")
-
-// Добавить в модель VoucherUsage:
-//  metadata         Json?
-//  usedAt           DateTime  @default(now())
 
 // Добавить в модель Merchant:
 //  rating           Float?

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -226,7 +226,6 @@ model Merchant {
   // back-relations
   reviews                     Review[]
   referralPrograms            ReferralProgram[]
-  vouchers                    Voucher[]
   promoCodes                  PromoCode[]
   promoCodeMetrics            PromoCodeMetric[]
   promoCodeUsages             PromoCodeUsage[]
@@ -365,7 +364,6 @@ model Customer {
   consents                    Consent[]
   segments                    SegmentCustomer[]
   // back-relations
-  voucherUsages               VoucherUsage[]
   promoCodeUsages             PromoCodeUsage[]
   reviews                     Review[]
   reviewReactions             ReviewReaction[]
@@ -1403,72 +1401,6 @@ model PersonalReferralCode {
   program ReferralProgram? @relation(fields: [programId], references: [id])
 
   @@unique([customerId, merchantId])
-}
-
-// Voucher models
-model Voucher {
-  id                   String    @id @default(cuid())
-  merchantId           String
-  name                 String
-  description          String?
-  type                 String // DISCOUNT, GIFT_CARD, PROMO_CODE
-  valueType            String // PERCENTAGE, FIXED_AMOUNT, POINTS
-  value                Int
-  minPurchase          Int?
-  maxUses              Int?
-  usedCount            Int       @default(0)
-  validFrom            DateTime?
-  validUntil           DateTime?
-  isActive             Boolean   @default(true)
-  metadata             Json?
-  status               String    @default("ACTIVE")
-  quantity             Int       @default(1)
-  remainingQuantity    Int       @default(1)
-  maxUsesPerCustomer   Int?
-  maxTotalUses         Int?
-  minPurchaseAmount    Int?
-  applicableProducts   String[]
-  applicableCategories String[]
-  totalUsed            Int       @default(0)
-  createdAt            DateTime  @default(now())
-  updatedAt            DateTime  @updatedAt
-
-  merchant Merchant       @relation(fields: [merchantId], references: [id])
-  codes    VoucherCode[]
-  usages   VoucherUsage[]
-}
-
-model VoucherCode {
-  id         String    @id @default(cuid())
-  voucherId  String
-  code       String    @unique
-  status     String    @default("ACTIVE")
-  maxUses    Int       @default(1)
-  usedCount  Int       @default(0)
-  validFrom  DateTime?
-  validUntil DateTime?
-  createdAt  DateTime  @default(now())
-
-  voucher Voucher        @relation(fields: [voucherId], references: [id])
-  usages  VoucherUsage[]
-}
-
-model VoucherUsage {
-  id         String   @id @default(cuid())
-  voucherId  String
-  codeId     String?
-  customerId String
-  orderId    String?
-  amount     Int
-  metadata   Json?
-  usedAt     DateTime @default(now())
-  createdAt  DateTime @default(now())
-
-  voucher  Voucher      @relation(fields: [voucherId], references: [id])
-  code     VoucherCode? @relation(fields: [codeId], references: [id])
-  customer Customer     @relation(fields: [customerId], references: [id])
-
-  @@unique([voucherId, customerId, orderId])
 }
 
 model PromoCode {

--- a/plan.md
+++ b/plan.md
@@ -255,7 +255,8 @@
     - «Сгорание (TTL)» (`/loyalty/mechanics/ttl`) — управление `pointsTtlDays` и `rulesJson.burnReminder` (enabled/daysBefore/text).
   - Merchant Portal: `auto-return` сохранение рефакторено — отправляется минимальный DTO (`earnBps`, `redeemLimitBps`, `rulesJson`) вместо полного объекта настроек.
   - Требуется обновить e2e под новый `PromoCodesService` (earn/commit/idempotency) — старые сценарии на ваучеры удалены.
-  - Prisma: индексы `VoucherUsage` остаются для обратной совместимости, но новая логика работает с `PromoCodeUsage`.
+  - Prisma: legacy таблицы `Voucher*` удалены — остались только `PromoCode*`, внешних интеграций/отчётов на них не осталось.
+  - Seeds/fixtures: генераторов записей ваучеров не осталось — чистка не требуется.
   - SDK TS: поле запроса переименовано в `promoCode`, удалён клиент `vouchers.*`.
   - README и документация обновлены под промокоды портала вместо ваучеров.
   - Все тесты зелёные: `pnpm -C api test && pnpm -C api test:e2e`.
@@ -268,7 +269,7 @@
   - Levels x TTL interplay: при metric=earn активация PENDING(120) поднимает уровень до Silver; quote на 1000 даёт 70 баллов (700 bps) — `levels.ttl.interplay.e2e-spec.ts`.
   - Метрики: e2e проверки /metrics после превью и burn (`metrics.workers.e2e-spec.ts`), gauge `loyalty_worker_last_tick_seconds`, счётчики burn.
   - Referrals: e2e‑заглушки контроллера с mock Prisma (`referral.e2e-spec.ts`); подключён `ReferralModule`, экспортирован `LoyaltyService` из `LoyaltyModule`.
-  - Docs: `API_DOCUMENTATION.md` — добавлены примеры конфигов уровней и раздел «Порядок применения» (Voucher → Promo → Rules + Levels) с формулами и примерами.
+  - Docs: `API_DOCUMENTATION.md` — добавлены примеры конфигов уровней и раздел «Порядок применения» (Promo → Rules + Levels) с формулами и примерами; подчёркнуто, что поддерживаются только промокоды.
   - Admin: единый поповер «эффективные ставки» (`admin/components/EffectiveRatesPopover.tsx`) подключён на страницах `customers` и `levels`.
   - E2E REDEEM: пер‑заказный cap — `redeem.order.cap.e2e-spec.ts` (учёт `receipt.redeemApplied`), дневной cap — `redeem.daily.cap.e2e-spec.ts` (rolling 24h) — оба зелёные.
   - Docs: `README.md` дополнен Quickstart «Levels + TTL». `API_DOCUMENTATION.md` — раздел «Referrals (beta/preview)» и примечания к REDEEM (per‑order cap и daily cap).


### PR DESCRIPTION
## Summary
- remove legacy Voucher relations from the Prisma schema and delete the models
- add a Prisma migration dropping the Voucher*, VoucherCode*, and VoucherUsage tables
- document that only PromoCode is supported and that no external dependencies remain

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db675bc6648324952fed47b0b8e757