### PR TITLE
Remove deviceId from loyalty contracts and documentation

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -49,8 +49,8 @@ X-Bridge-Signature: v1,ts=1234567890,sig=base64signature
 
 Где применяется (включается per-merchant настройкой `requireBridgeSig`):
 - `POST /loyalty/quote` — при включённой настройке, сигнатура обязательна.
-- `POST /loyalty/commit` — проверяется до выполнения; если hold привязан к устройству, используется секрет устройства (`Device.bridgeSecret`) вместо мерчантского.
-- `POST /loyalty/refund` — аналогично `commit`; новые клиенты передают только `outletId` (поле `deviceId` поддерживается для легаси-запросов).
+- `POST /loyalty/commit` — проверяется до выполнения; если hold привязан к торговой точке, используется секрет точки (`Outlet.bridgeSecret` или `bridgeSecretNext`) вместо мерчантского.
+- `POST /loyalty/refund` — аналогично `commit`; для новых интеграций требуется `outletId`.
 - `POST /loyalty/qr` — если нет TeleAuth и Staff-Key, при включённой настройке требуется подпись.
 
 Совместимость со Staff-Key: если у мерчанта включено требование Staff-Key (`requireStaffKey`), допускается либо `X-Staff-Key`, либо `X-Bridge-Signature` (см. `loyalty.controller.ts: enforceRequireStaffKey`).
@@ -185,7 +185,6 @@ X-Staff-Key: required_if_enabled
   "total": 1000,
   "eligibleTotal": 1000,
   "outletId": "string", // optional
-  "deviceId": "string", // optional
   "staffId": "string",  // optional
   "category": "string",  // optional (для правил промо)
   "promoCode": "string" // optional (применить промокод перед расчётом)
@@ -420,7 +419,6 @@ X-Staff-Key: required_if_enabled
   "orderId": "string",
   "refundTotal": 1000,
   "refundEligibleTotal": 1000 // optional
-  // legacy: допустимо передавать deviceId для старых интеграций
 }
 
 Response 200:
@@ -1070,7 +1068,7 @@ Content-Type: application/json
   "customerId": "string",
   "amount": 10000,
   "type": "REDEEM",
-  "deviceId": "string",
+  "outletId": "string",
   "ipAddress": "192.168.1.1"
 }
 
@@ -1080,7 +1078,7 @@ Response 200:
   "score": 25,
   "factors": [
     "large_amount:10000",
-    "new_device"
+    "new_outlet"
   ],
   "shouldBlock": false,
   "shouldReview": false

--- a/api/openapi.generated.json
+++ b/api/openapi.generated.json
@@ -2824,9 +2824,6 @@
           "outletId": {
             "type": "string"
           },
-          "deviceId": {
-            "type": "string"
-          },
           "staffId": {
             "type": "string"
           },
@@ -3070,7 +3067,8 @@
             "type": "number"
           },
           "orderId": {
-            "type": "object"
+            "type": "string",
+            "nullable": true
           },
           "customerId": {
             "type": "string"
@@ -3079,13 +3077,21 @@
             "type": "string"
           },
           "outletId": {
-            "type": "object"
+            "type": "string",
+            "nullable": true
           },
-          "deviceId": {
-            "type": "object"
+          "outletPosType": {
+            "type": "string",
+            "nullable": true
+          },
+          "outletLastSeenAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
           },
           "staffId": {
-            "type": "object"
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [

--- a/api/src/antifraud/antifraud.service.spec.ts
+++ b/api/src/antifraud/antifraud.service.spec.ts
@@ -56,23 +56,22 @@ describe('AntiFraudService (outlet factors)', () => {
     expect(result.factors).toEqual(expect.arrayContaining(['new_outlet', 'multiple_outlets:4']));
   });
 
-  it('фолбэчит на deviceId, если outletId не передан', async () => {
-    prisma.transaction.count.mockResolvedValueOnce(2);
-    prisma.transaction.findMany.mockResolvedValueOnce([{ deviceId: 'D-1' }]);
+  it('не добавляет no_outlet_id, если outletId указан и есть история', async () => {
+    prisma.transaction.count.mockResolvedValueOnce(3);
+    prisma.transaction.findMany.mockResolvedValueOnce([{ outletId: 'O-1' }, { outletId: 'O-2' }]);
 
     const result = await (service as any).checkOutlet({
       merchantId: 'M-1',
       customerId: 'C-2',
       amount: 50,
       type: 'REDEEM',
-      deviceId: 'D-1',
+      outletId: 'O-1',
     });
 
     expect(prisma.transaction.count).toHaveBeenCalledWith(
-      expect.objectContaining({ where: expect.objectContaining({ deviceId: 'D-1' }) }),
+      expect.objectContaining({ where: expect.objectContaining({ outletId: 'O-1' }) }),
     );
     expect(result.factors).not.toContain('no_outlet_id');
-    expect(result.factors).toHaveLength(0);
   });
 
   it('сводит статистику с учётом riskLevel и факторов', async () => {

--- a/api/src/earn-activation.worker.spec.ts
+++ b/api/src/earn-activation.worker.spec.ts
@@ -12,7 +12,7 @@ describe('EarnActivationWorker (unit)', () => {
     jest.spyOn(lockUtil, 'pgAdvisoryUnlock').mockResolvedValue(undefined);
 
     const maturedAt = new Date(Date.now() - 1000);
-    const pendingLot = { id: 'L1', merchantId: 'M1', customerId: 'C1', points: 70, consumedPoints: 0, maturesAt: maturedAt, earnedAt: null, status: 'PENDING', orderId: 'O1', outletId: null, deviceId: null, staffId: null } as any;
+    const pendingLot = { id: 'L1', merchantId: 'M1', customerId: 'C1', points: 70, consumedPoints: 0, maturesAt: maturedAt, earnedAt: null, status: 'PENDING', orderId: 'O1', outletId: null, staffId: null } as any;
 
     const tx = {
       earnLot: {

--- a/api/src/guards/antifraud.guard.spec.ts
+++ b/api/src/guards/antifraud.guard.spec.ts
@@ -51,7 +51,6 @@ describe('AntiFraudGuard', () => {
       earnPoints: 100,
       redeemAmount: 0,
       outletId: null,
-      deviceId: null,
       staffId: 'S-1',
     });
     prisma.merchantSettings.findUnique.mockResolvedValue({
@@ -73,7 +72,7 @@ describe('AntiFraudGuard', () => {
     expect(antifraud.checkTransaction).not.toHaveBeenCalled();
   });
 
-  it('использует deviceId в лимитах, если outletId отсутствует', async () => {
+  it('использует outletId в лимитах, если он указан', async () => {
     prisma.hold.findUnique.mockResolvedValue({
       id: 'H-2',
       merchantId: 'M-1',
@@ -81,8 +80,7 @@ describe('AntiFraudGuard', () => {
       mode: 'EARN',
       earnPoints: 200,
       redeemAmount: 0,
-      outletId: null,
-      deviceId: 'D-1',
+      outletId: 'O-1',
       staffId: 'S-2',
     });
     prisma.merchantSettings.findUnique.mockResolvedValue({
@@ -107,7 +105,7 @@ describe('AntiFraudGuard', () => {
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
     expect(prisma.transaction.count).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ deviceId: 'D-1' }),
+        where: expect.objectContaining({ outletId: 'O-1' }),
       }),
     );
     expect(alerts.antifraudBlocked).not.toHaveBeenCalled();

--- a/api/src/guards/custom-throttler.guard.spec.ts
+++ b/api/src/guards/custom-throttler.guard.spec.ts
@@ -6,26 +6,27 @@ describe('CustomThrottlerGuard.getTracker', () => {
     const req: any = {
       ip: '127.0.0.1',
       route: { path: '/loyalty/commit' },
-      body: { merchantId: 'M-1', outletId: 'O-1', deviceId: 'D-1', staffId: 'S-1' },
+      body: { merchantId: 'M-1', outletId: 'O-1', staffId: 'S-1' },
       query: {},
     };
     const key = await (g as any).getTracker(req);
     const parts = key.split('|');
     expect(parts).toContain('O-1');
-    expect(parts).not.toContain('D-1');
+    expect(parts).not.toContain('undefined');
   });
 
-  it('использует deviceId в качестве фолбэка, если outletId отсутствует', async () => {
+  it('формирует ключ без outletId, если он отсутствует', async () => {
     const g = new CustomThrottlerGuard({} as any, {} as any, {} as any);
     const req: any = {
       ip: '10.0.0.1',
       route: { path: '/loyalty/refund' },
-      body: { merchantId: 'M-2', deviceId: 'D-2', staffId: 'S-2' },
+      body: { merchantId: 'M-2', staffId: 'S-2' },
       query: {},
     };
     const key = await (g as any).getTracker(req);
     const parts = key.split('|');
-    expect(parts).toContain('D-2');
+    expect(parts).toContain('M-2');
+    expect(parts).not.toContain('undefined');
   });
 });
 

--- a/api/src/loyalty/loyalty.service.spec.ts
+++ b/api/src/loyalty/loyalty.service.spec.ts
@@ -48,7 +48,7 @@ describe('LoyaltyService.commit idempotency', () => {
 
   it('commit EARN creates receipt and returns ok', async () => {
     const prisma = mkPrisma();
-    const hold = { id: 'H2', merchantId: 'M-1', customerId: 'C-2', status: 'PENDING', mode: 'EARN', earnPoints: 5, outletId: null, deviceId: null, staffId: null, total: 100, eligibleTotal: 100 };
+    const hold = { id: 'H2', merchantId: 'M-1', customerId: 'C-2', status: 'PENDING', mode: 'EARN', earnPoints: 5, outletId: null, staffId: null, total: 100, eligibleTotal: 100 };
     prisma.hold.findUnique.mockResolvedValue(hold);
     prisma.wallet.findFirst.mockResolvedValue({ id: 'W2', balance: 0, type: 'POINTS' });
     let txUsed: any;
@@ -65,7 +65,7 @@ describe('LoyaltyService.commit idempotency', () => {
 
   it('commit touches outlet when present', async () => {
     const prisma = mkPrisma();
-    const hold = { id: 'H3', merchantId: 'M-1', customerId: 'C-3', status: 'PENDING', mode: 'EARN', earnPoints: 5, outletId: 'OUT-1', deviceId: null, staffId: null, total: 100, eligibleTotal: 100 };
+    const hold = { id: 'H3', merchantId: 'M-1', customerId: 'C-3', status: 'PENDING', mode: 'EARN', earnPoints: 5, outletId: 'OUT-1', staffId: null, total: 100, eligibleTotal: 100 };
     prisma.hold.findUnique.mockResolvedValue(hold);
     prisma.wallet.findFirst.mockResolvedValue({ id: 'W3', balance: 0, type: 'POINTS' });
     let txUsed: any;

--- a/api/test/crm.e2e-spec.ts
+++ b/api/test/crm.e2e-spec.ts
@@ -11,11 +11,11 @@ describe('CRM (e2e)', () => {
     customers: [{ id: 'C1', phone: '+79990000001' }, { id: 'C2', phone: '+79990000002' }],
     wallets: [{ id: 'W1', merchantId: 'M1', customerId: 'C1', balance: 150 }],
     txns: [
-      { id: 'T1', merchantId: 'M1', customerId: 'C1', type: 'EARN', amount: 50, orderId: 'O1', createdAt: new Date(), outletId: null, deviceId: null, staffId: null },
-      { id: 'T2', merchantId: 'M1', customerId: 'C1', type: 'REDEEM', amount: -25, orderId: 'O2', createdAt: new Date(Date.now()-3600_000), outletId: null, deviceId: null, staffId: null },
+      { id: 'T1', merchantId: 'M1', customerId: 'C1', type: 'EARN', amount: 50, orderId: 'O1', createdAt: new Date(), outletId: null, staffId: null },
+      { id: 'T2', merchantId: 'M1', customerId: 'C1', type: 'REDEEM', amount: -25, orderId: 'O2', createdAt: new Date(Date.now()-3600_000), outletId: null, staffId: null },
     ],
     receipts: [
-      { id: 'R1', merchantId: 'M1', customerId: 'C1', orderId: 'O1', total: 1000, eligibleTotal: 900, redeemApplied: 0, earnApplied: 50, createdAt: new Date(), outletId: null, deviceId: null, staffId: null },
+      { id: 'R1', merchantId: 'M1', customerId: 'C1', orderId: 'O1', total: 1000, eligibleTotal: 900, redeemApplied: 0, earnApplied: 50, createdAt: new Date(), outletId: null, staffId: null },
     ],
   };
 

--- a/api/test/levels.ttl.interplay.e2e-spec.ts
+++ b/api/test/levels.ttl.interplay.e2e-spec.ts
@@ -99,7 +99,7 @@ describe('Levels x TTL interplay (e2e)', () => {
     });
 
     // PENDING lot that matured in the past with 120 points → after activation, we cross Silver threshold
-    state.lots.push({ id: 'LOT-1', merchantId: 'M-L2', customerId: 'C-L2', points: 120, consumedPoints: 0, status: 'PENDING', maturesAt: d(2), earnedAt: null, orderId: 'O-L2-1', outletId: null, deviceId: null, staffId: null });
+    state.lots.push({ id: 'LOT-1', merchantId: 'M-L2', customerId: 'C-L2', points: 120, consumedPoints: 0, status: 'PENDING', maturesAt: d(2), earnedAt: null, orderId: 'O-L2-1', outletId: null, staffId: null });
 
     const moduleFixture: TestingModule = await Test.createTestingModule({ imports: [AppModule] })
       .overrideProvider(PrismaService)

--- a/api/test/ttl.flow.e2e-spec.ts
+++ b/api/test/ttl.flow.e2e-spec.ts
@@ -10,7 +10,7 @@ describe('TTL full flow (lots + PENDING -> activation -> preview -> burn)', () =
   const state = {
     lots: [
       // matured in the past (40 days ago), will be ACTIVATED and immediately expired by TTL(30)
-      { id: 'L1', merchantId: 'M1', customerId: 'C1', points: 100, consumedPoints: 0, status: 'PENDING', maturesAt: d(40), earnedAt: null as any, orderId: 'O1', outletId: null, deviceId: null, staffId: null },
+      { id: 'L1', merchantId: 'M1', customerId: 'C1', points: 100, consumedPoints: 0, status: 'PENDING', maturesAt: d(40), earnedAt: null as any, orderId: 'O1', outletId: null, staffId: null },
     ] as any[],
     wallet: { id: 'W1', merchantId: 'M1', customerId: 'C1', type: 'POINTS', balance: 0 },
   };

--- a/plan.md
+++ b/plan.md
@@ -14,7 +14,8 @@
 
 — Устройства: депрекация. UI/роуты удаляем, опираемся на Торговые точки.
   - [x] Бэкенд-агрегации/выгрузки перевёл на `outletId`: аналитика (Top Devices → Outlet usage c `posLastSeenAt`), воркер активации начислений, CRM-таймлайн, push-устройства (`outletDeviceKey`), интеграционные DTO и CSV/SDK.
-  - [x] DTO/ответы merchants/loyalty и клиенты (admin/bridge/cashier) очищены от `deviceId`, добавлены поля POS-агрегации (`outletPosType`, `outletLastSeenAt`).
+- [x] DTO/ответы merchants/loyalty и клиенты (admin/bridge/cashier) очищены от `deviceId`, добавлены поля POS-агрегации (`outletPosType`, `outletLastSeenAt`).
+- [x] OpenAPI/документация и e2e/контрактные тесты приведены к схеме без `deviceId`; зафиксированы outlet-секреты.
 
 ## Батчи внедрения (план)
 


### PR DESCRIPTION
## Summary
- очистил e2e/контрактные тесты и моки API от зависимостей `deviceId`, переключив сценарии на `outletId` и обновив вспомогательные структуры
- обновил OpenAPI-спеку и API_DOCUMENTATION.md: убраны поля `deviceId`, добавлены POS-атрибуты торговых точек и актуализировано описание outlet-секретов
- зафиксировал выполненную работу в plan.md

## Testing
- PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm --filter api exec jest *(failed: отсутствует сгенерированный Prisma client в офлайн-окружении, prisma generate недоступен)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe0f184048324b3d8800350441315