### PR TITLE
refactor: drop device references from loyalty service

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -16,6 +16,7 @@
   - [x] Бэкенд-агрегации/выгрузки перевёл на `outletId`: аналитика (Top Devices → Outlet usage c `posLastSeenAt`), воркер активации начислений, CRM-таймлайн, push-устройства (`outletDeviceKey`), интеграционные DTO и CSV/SDK.
 - [x] DTO/ответы merchants/loyalty и клиенты (admin/bridge/cashier) очищены от `deviceId`, добавлены поля POS-агрегации (`outletPosType`, `outletLastSeenAt`).
 - [x] OpenAPI/документация и e2e/контрактные тесты приведены к схеме без `deviceId`; зафиксированы outlet-секреты.
+  - [x] LoyaltyService: расчёт/commit/refund и outbox работают только с `outletId`, записи `deviceId` прекращены.
 
 ## Батчи внедрения (план)
 


### PR DESCRIPTION
## Summary
- remove deviceId usage from loyalty service holds, transactions, ledger entries, and outbox events so operations rely on outletId only
- adjust outlet context resolution to ignore devices and update plan.md to reflect the change

## Testing
- pnpm --filter api lint *(fails: thousands of pre-existing @typescript-eslint no-unsafe/require-await errors across api tests)*
- pnpm --filter api test *(fails: prisma generate cannot download engines — HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe7b13c008324a92cce581f913ad6