### PR TITLE
Перевод guard'ов на outletId

### DIFF
--- a/api/src/guards/cashier.guard.spec.ts
+++ b/api/src/guards/cashier.guard.spec.ts
@@ -1,0 +1,105 @@
+import { ExecutionContext } from '@nestjs/common';
+import { CashierGuard } from './cashier.guard';
+import * as crypto from 'crypto';
+
+describe('CashierGuard', () => {
+  const hashKey = (key: string) => crypto.createHash('sha256').update(key, 'utf8').digest('hex');
+  let prisma: any;
+  let guard: CashierGuard;
+
+  const makeCtx = (req: any): ExecutionContext => ({
+    switchToHttp: () => ({ getRequest: () => req }),
+  } as any);
+
+  beforeEach(() => {
+    prisma = {
+      merchantSettings: { findUnique: jest.fn().mockResolvedValue({ requireStaffKey: true }) },
+      staff: { findFirst: jest.fn() },
+    };
+    guard = new CashierGuard(prisma);
+  });
+
+  it('разрешает доступ администраторам независимо от outletId', async () => {
+    const key = 'adm-key';
+    prisma.staff.findFirst.mockImplementation(async (args: any) => {
+      if (args.where.apiKeyHash === hashKey(key)) {
+        return { id: 'S-admin', role: 'ADMIN', accesses: [] };
+      }
+      return null;
+    });
+
+    const ctx = makeCtx({
+      method: 'POST',
+      route: { path: '/loyalty/quote' },
+      headers: { 'x-staff-key': key },
+      body: { merchantId: 'M1', outletId: 'O-1' },
+      query: {},
+      params: {},
+    });
+
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it('блокирует кассира с allowedOutletId при несовпадении outlet', async () => {
+    const key = 'cashier-key';
+    prisma.staff.findFirst.mockImplementation(async (args: any) => {
+      if (args.where.apiKeyHash === hashKey(key)) {
+        return { id: 'S-cashier', role: 'CASHIER', allowedOutletId: 'O-1', accesses: [] };
+      }
+      return null;
+    });
+
+    const ctx = makeCtx({
+      method: 'POST',
+      route: { path: '/loyalty/commit' },
+      headers: { 'x-staff-key': key },
+      body: { merchantId: 'M1', outletId: 'O-2' },
+      query: {},
+      params: {},
+    });
+
+    await expect(guard.canActivate(ctx)).resolves.toBe(false);
+  });
+
+  it('разрешает кассиру с доступом к точке через StaffOutletAccess', async () => {
+    const key = 'cashier-allowed';
+    prisma.staff.findFirst.mockImplementation(async (args: any) => {
+      if (args.where.apiKeyHash === hashKey(key)) {
+        return { id: 'S-cashier', role: 'CASHIER', allowedOutletId: null, accesses: [{ outletId: 'O-3' }] };
+      }
+      return null;
+    });
+
+    const ctx = makeCtx({
+      method: 'POST',
+      route: { path: '/loyalty/refund' },
+      headers: { 'x-staff-key': key },
+      body: { merchantId: 'M1', outletId: 'O-3' },
+      query: {},
+      params: {},
+    });
+
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it('требует outletId для кассира с ограничениями по точкам', async () => {
+    const key = 'cashier-missing-outlet';
+    prisma.staff.findFirst.mockImplementation(async (args: any) => {
+      if (args.where.apiKeyHash === hashKey(key)) {
+        return { id: 'S-cashier', role: 'CASHIER', allowedOutletId: null, accesses: [{ outletId: 'O-4' }] };
+      }
+      return null;
+    });
+
+    const ctx = makeCtx({
+      method: 'POST',
+      route: { path: '/loyalty/commit' },
+      headers: { 'x-staff-key': key },
+      body: { merchantId: 'M1' },
+      query: {},
+      params: {},
+    });
+
+    await expect(guard.canActivate(ctx)).resolves.toBe(false);
+  });
+});

--- a/api/src/guards/custom-throttler.guard.spec.ts
+++ b/api/src/guards/custom-throttler.guard.spec.ts
@@ -15,7 +15,7 @@ describe('CustomThrottlerGuard.getTracker', () => {
     expect(parts).not.toContain('undefined');
   });
 
-  it('формирует ключ без outletId, если он отсутствует', async () => {
+  it('использует staffId, если outletId отсутствует', async () => {
     const g = new CustomThrottlerGuard({} as any, {} as any, {} as any);
     const req: any = {
       ip: '10.0.0.1',
@@ -26,6 +26,7 @@ describe('CustomThrottlerGuard.getTracker', () => {
     const key = await (g as any).getTracker(req);
     const parts = key.split('|');
     expect(parts).toContain('M-2');
+    expect(parts).toContain('S-2');
     expect(parts).not.toContain('undefined');
   });
 });

--- a/api/src/guards/custom-throttler.guard.ts
+++ b/api/src/guards/custom-throttler.guard.ts
@@ -12,10 +12,8 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
       const q = req.query || {};
       const merchantId = body.merchantId || q.merchantId || '';
       const outletId = body.outletId || q.outletId || '';
-      const deviceId = body.deviceId || q.deviceId || '';
       const staffId = body.staffId || q.staffId || '';
-      const outletKey = outletId || deviceId || '';
-      return [ip, path, merchantId, outletKey, staffId].filter(Boolean).join('|');
+      return [ip, path, merchantId, outletId, staffId].filter(Boolean).join('|');
     } catch {
       return await super.getTracker(req as any);
     }

--- a/api/test/antifraud.e2e-spec.ts
+++ b/api/test/antifraud.e2e-spec.ts
@@ -125,7 +125,7 @@ describe('AntiFraud Guard (e2e)', () => {
       rulesJson: {
         af: {
           merchant: { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
-          device:   { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
+          outlet:   { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
           staff:    { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
           customer: { limit: 1,   windowSec: 3600, dailyCap: 0, weeklyCap: 0 },
           blockFactors: [],
@@ -177,7 +177,7 @@ describe('AntiFraud Guard (e2e)', () => {
       rulesJson: {
         af: {
           merchant: { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
-          device:   { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
+          outlet:   { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
           staff:    { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
           customer: { limit: 5,   windowSec: 60,  dailyCap: 0, weeklyCap: 0 },
           blockFactors: ['no_outlet_id']
@@ -204,7 +204,7 @@ describe('AntiFraud Guard (e2e)', () => {
       rulesJson: {
         af: {
           merchant: { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
-          device:   { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
+          outlet:   { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
           staff:    { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
           customer: { limit: 99,  windowSec: 60, dailyCap: 0, weeklyCap: 0 }
         }
@@ -238,7 +238,7 @@ describe('AntiFraud Guard (e2e)', () => {
       rulesJson: {
         af: {
           merchant: { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
-          device:   { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
+          outlet:   { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
           staff:    { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
           customer: { limit: 99,  windowSec: 60, dailyCap: 1, weeklyCap: 0 }
         }
@@ -260,21 +260,21 @@ describe('AntiFraud Guard (e2e)', () => {
     expect(String(r.body.message || '')).toMatch(/превышен лимит/);
   });
 
-  it('Device velocity: блокировка при превышении лимита по device в окне', async () => {
-    // Настраиваем лимит по device = 1 за 1 час
+  it('Outlet velocity: блокировка при превышении лимита по торговой точке в окне', async () => {
+    // Настраиваем лимит по outlet = 1 за 1 час
     state.merchantSettings.set('M-af', {
       ...(state.merchantSettings.get('M-af')!),
       rulesJson: {
         af: {
           merchant: { limit: 999, windowSec: 3600, dailyCap: 0, weeklyCap: 0 },
-          device:   { limit: 1,   windowSec: 3600, dailyCap: 0, weeklyCap: 0 },
+          outlet:   { limit: 1,   windowSec: 3600, dailyCap: 0, weeklyCap: 0 },
           staff:    { limit: 999, windowSec: 3600, dailyCap: 0, weeklyCap: 0 },
           customer: { limit: 999, windowSec: 3600, dailyCap: 0, weeklyCap: 0 }
         }
       }
     });
 
-    // Уже есть 1 транзакция от устройства D-vel
+    // Уже есть 1 транзакция по точке O-vel
     state.transactions.push({ id: uuid(), merchantId: 'M-af', customerId: 'C-dev0', outletId: 'O-vel', staffId: null, createdAt: new Date() });
 
     const q = await request(app.getHttpServer())
@@ -284,7 +284,7 @@ describe('AntiFraud Guard (e2e)', () => {
     const holdId = q.body.holdId as string;
     const r = await request(app.getHttpServer())
       .post('/loyalty/commit')
-      .send({ holdId, orderId: 'O-dev-2' })
+      .send({ holdId, orderId: 'O-outlet-2' })
       .expect(429);
     expect(String(r.body.message || '')).toMatch(/превышен лимит/);
   });
@@ -295,7 +295,7 @@ describe('AntiFraud Guard (e2e)', () => {
       rulesJson: {
         af: {
           merchant: { limit: 999, windowSec: 3600, dailyCap: 0, weeklyCap: 0 },
-          device:   { limit: 999, windowSec: 3600, dailyCap: 0, weeklyCap: 0 },
+          outlet:   { limit: 999, windowSec: 3600, dailyCap: 0, weeklyCap: 0 },
           staff:    { limit: 1,   windowSec: 3600, dailyCap: 0, weeklyCap: 0 },
           customer: { limit: 999, windowSec: 3600, dailyCap: 0, weeklyCap: 0 }
         }
@@ -321,7 +321,7 @@ describe('AntiFraud Guard (e2e)', () => {
     // Отдельный мерчант
     state.merchantSettings.set('M-cap', {
       merchantId: 'M-cap', earnBps: 1000, redeemLimitBps: 5000, qrTtlSec: 120, requireStaffKey: false,
-      rulesJson: { af: { merchant: { limit: 1, windowSec: 3600, dailyCap: 0, weeklyCap: 0 }, device: { limit: 999, windowSec: 3600 }, staff: { limit: 999, windowSec: 3600 }, customer: { limit: 999, windowSec: 3600 } } },
+      rulesJson: { af: { merchant: { limit: 1, windowSec: 3600, dailyCap: 0, weeklyCap: 0 }, outlet: { limit: 999, windowSec: 3600 }, staff: { limit: 999, windowSec: 3600 }, customer: { limit: 999, windowSec: 3600 } } },
       updatedAt: new Date()
     });
     state.transactions.push({ id: uuid(), merchantId: 'M-cap', customerId: 'C-x', outletId: null, staffId: null, createdAt: new Date() });
@@ -338,7 +338,7 @@ describe('AntiFraud Guard (e2e)', () => {
     expect(String(r.body.message || '')).toMatch(/превышен лимит/);
   });
 
-  it('Refund device limit: блокировка рефанда по лимиту устройства', async () => {
+  it('Refund outlet limit: блокировка рефанда по лимиту торговой точки', async () => {
     // Создаём квоту и коммит без ограничений, чтобы появился чек (мерчант M-ref)
     state.merchantSettings.set('M-ref', { merchantId: 'M-ref', earnBps: 1000, redeemLimitBps: 5000, qrTtlSec: 120, requireStaffKey: false, updatedAt: new Date() });
     const q1 = await request(app.getHttpServer())
@@ -351,10 +351,10 @@ describe('AntiFraud Guard (e2e)', () => {
       .send({ holdId: holdId1, orderId: 'O-ref-1' })
       .expect(201);
 
-    // Включаем device.limit=0 (запрещено всё)
+    // Включаем outlet.limit=0 (запрещено всё)
     state.merchantSettings.set('M-ref', {
       ...(state.merchantSettings.get('M-ref')!),
-      rulesJson: { af: { merchant: { limit: 999, windowSec: 3600 }, device: { limit: 0, windowSec: 3600 }, staff: { limit: 999, windowSec: 3600 }, customer: { limit: 999, windowSec: 3600 } } }
+      rulesJson: { af: { merchant: { limit: 999, windowSec: 3600 }, outlet: { limit: 0, windowSec: 3600 }, staff: { limit: 999, windowSec: 3600 }, customer: { limit: 999, windowSec: 3600 } } }
     });
 
     // Рефанд с outletId -> должен заблокироваться антифродом
@@ -371,7 +371,7 @@ describe('AntiFraud Guard (e2e)', () => {
       rulesJson: {
         af: {
           merchant: { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
-          device:   { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
+          outlet:   { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
           staff:    { limit: 999, windowSec: 60, dailyCap: 0, weeklyCap: 0 },
           customer: { limit: 99,  windowSec: 60, dailyCap: 0, weeklyCap: 1 }
         }

--- a/plan.md
+++ b/plan.md
@@ -17,7 +17,8 @@
 - [x] DTO/ответы merchants/loyalty и клиенты (admin/bridge/cashier) очищены от `deviceId`, добавлены поля POS-агрегации (`outletPosType`, `outletLastSeenAt`).
 - [x] OpenAPI/документация и e2e/контрактные тесты приведены к схеме без `deviceId`; зафиксированы outlet-секреты.
   - [x] LoyaltyController окончательно отказался от `deviceId`: подпись Bridge/hold кешируются только по `outletId`, публичные DTO и роуты очищены.
-  - [x] LoyaltyService: расчёт/commit/refund и outbox работают только с `outletId`, записи `deviceId` прекращены.
+- [x] LoyaltyService: расчёт/commit/refund и outbox работают только с `outletId`, записи `deviceId` прекращены.
+- [x] Guard'ы: троттлер, антифрод и кассир работают без `deviceId`, опираются на `outletId` и роли сотрудников.
 
 ## Батчи внедрения (план)
 


### PR DESCRIPTION
## Summary
- перевёл кастомный throttler на формирование ключа по outletId/staffId вместо deviceId
- обновил AntiFraudGuard: лимиты и алерты работают только по outletId, вызовы antifraud-сервиса очищены от deviceId
- расширил CashierGuard проверкой ролей и доступа к точкам, добавил/обновил unit и e2e тесты, актуализировал plan.md

## Testing
- `pnpm --filter api test` *(падает: Prisma CLI не может скачать движок из-за 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dc977220c48324bcbacfc0fafbce88