### PR TITLE
Remove legacy Device model

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ API управления секретами/статусами точек:
 - Обновление POS-статуса: `PUT /merchants/:id/outlets/:outletId/pos` (поля `posType`, `posLastSeenAt`).
 - Переключение точки (ACTIVE/INACTIVE): `PUT /merchants/:id/outlets/:outletId/status`.
 
-> Новые клиенты POS Bridge используют `outletId` + `bridgeSecret`. Поддержка `deviceId` сохранена только для обратной совместимости.
+> POS Bridge теперь опирается только на `outletId` + `bridgeSecret`: таблица `Device` удалена, а `deviceId` больше не хранится в моделях.
 
-> Миграция `20251025120000_device_pos_fields` переносит существующие данные из таблицы `Device` в новые поля `Outlet` по этим правилам, чтобы сервисы могли работать только с торговыми точками.
+> Миграция `20251201090000_remove_device_table` добирает остаточные `bridgeSecret`/`lastSeen`, переносит ограничения сотрудников на точки и удаляет все поля `deviceId`. Ранее миграция `20251025120000_device_pos_fields` перенесла первичные данные из `Device` в `Outlet`.
 
 ## Проверка E2E (понятно и по шагам)
 

--- a/admin/lib/admin.ts
+++ b/admin/lib/admin.ts
@@ -256,7 +256,6 @@ export type Staff = {
   status: 'ACTIVE' | 'INACTIVE';
   apiKeyHash?: string | null;
   allowedOutletId?: string | null;
-  allowedDeviceId?: string | null;
   createdAt: string;
   updatedAt?: string | null;
 };

--- a/admin/lib/staff.ts
+++ b/admin/lib/staff.ts
@@ -6,7 +6,7 @@ async function http<T>(path: string, init?: RequestInit): Promise<T> {
   return await res.json() as T;
 }
 
-export type Staff = { id: string; merchantId: string; login?: string | null; email?: string | null; role: string; status: string; allowedOutletId?: string | null; allowedDeviceId?: string | null; apiKeyHash?: string | null; createdAt: string };
+export type Staff = { id: string; merchantId: string; login?: string | null; email?: string | null; role: string; status: string; allowedOutletId?: string | null; apiKeyHash?: string | null; createdAt: string };
 
 export async function listStaff(merchantId: string): Promise<Staff[]> {
   return http(`/merchants/${encodeURIComponent(merchantId)}/staff`);
@@ -14,7 +14,7 @@ export async function listStaff(merchantId: string): Promise<Staff[]> {
 export async function createStaff(merchantId: string, dto: { login?: string; email?: string; role?: string }): Promise<Staff> {
   return http(`/merchants/${encodeURIComponent(merchantId)}/staff`, { method: 'POST', body: JSON.stringify(dto) });
 }
-export async function updateStaff(merchantId: string, staffId: string, dto: { login?: string; email?: string; role?: string; status?: string; allowedOutletId?: string; allowedDeviceId?: string }): Promise<Staff> {
+export async function updateStaff(merchantId: string, staffId: string, dto: { login?: string; email?: string; role?: string; status?: string; allowedOutletId?: string }): Promise<Staff> {
   return http(`/merchants/${encodeURIComponent(merchantId)}/staff/${encodeURIComponent(staffId)}`, { method: 'PUT', body: JSON.stringify(dto) });
 }
 export async function deleteStaff(merchantId: string, staffId: string): Promise<{ ok: boolean }> {

--- a/api/prisma/migrations/20251201090000_remove_device_table/migration.sql
+++ b/api/prisma/migrations/20251201090000_remove_device_table/migration.sql
@@ -1,0 +1,119 @@
+-- Backfill outlet metadata from remaining devices
+WITH device_ranked AS (
+    SELECT
+        d."outletId",
+        d."type",
+        COALESCE(d."lastSeenAt", d."createdAt") AS "effectiveLastSeen",
+        d."bridgeSecret",
+        ROW_NUMBER() OVER (
+            PARTITION BY d."outletId"
+            ORDER BY d."lastSeenAt" DESC NULLS LAST, d."createdAt" DESC
+        ) AS rn
+    FROM "public"."Device" d
+    WHERE d."outletId" IS NOT NULL
+),
+device_best AS (
+    SELECT
+        r."outletId",
+        r."type",
+        r."effectiveLastSeen",
+        r."bridgeSecret"
+    FROM device_ranked r
+    WHERE r.rn = 1
+)
+UPDATE "public"."Outlet" o
+SET
+    "posType" = COALESCE(b."type", o."posType"),
+    "posLastSeenAt" = CASE
+        WHEN b."effectiveLastSeen" IS NOT NULL THEN
+            CASE
+                WHEN o."posLastSeenAt" IS NULL OR b."effectiveLastSeen" > o."posLastSeenAt" THEN b."effectiveLastSeen"
+                ELSE o."posLastSeenAt"
+            END
+        ELSE o."posLastSeenAt"
+    END,
+    "bridgeSecret" = COALESCE(o."bridgeSecret", b."bridgeSecret"),
+    "bridgeSecretUpdatedAt" = CASE
+        WHEN o."bridgeSecret" IS NULL AND b."bridgeSecret" IS NOT NULL THEN COALESCE(o."bridgeSecretUpdatedAt", CURRENT_TIMESTAMP)
+        ELSE o."bridgeSecretUpdatedAt"
+    END
+FROM device_best b
+WHERE b."outletId" = o."id";
+
+-- Propagate outletId from devices where it is still missing
+UPDATE "public"."Hold" h
+SET "outletId" = d."outletId"
+FROM "public"."Device" d
+WHERE h."outletId" IS NULL
+  AND h."deviceId" = d."id"
+  AND d."outletId" IS NOT NULL;
+
+UPDATE "public"."Receipt" r
+SET "outletId" = d."outletId"
+FROM "public"."Device" d
+WHERE r."outletId" IS NULL
+  AND r."deviceId" = d."id"
+  AND d."outletId" IS NOT NULL;
+
+UPDATE "public"."Transaction" t
+SET "outletId" = d."outletId"
+FROM "public"."Device" d
+WHERE t."outletId" IS NULL
+  AND t."deviceId" = d."id"
+  AND d."outletId" IS NOT NULL;
+
+UPDATE "public"."LedgerEntry" l
+SET "outletId" = d."outletId"
+FROM "public"."Device" d
+WHERE l."outletId" IS NULL
+  AND l."deviceId" = d."id"
+  AND d."outletId" IS NOT NULL;
+
+UPDATE "public"."EarnLot" e
+SET "outletId" = d."outletId"
+FROM "public"."Device" d
+WHERE e."outletId" IS NULL
+  AND e."deviceId" = d."id"
+  AND d."outletId" IS NOT NULL;
+
+UPDATE "public"."CashierSession" cs
+SET "outletId" = d."outletId"
+FROM "public"."Device" d
+WHERE cs."outletId" IS NULL
+  AND cs."deviceId" = d."id"
+  AND d."outletId" IS NOT NULL;
+
+UPDATE "public"."Staff" s
+SET "allowedOutletId" = d."outletId"
+FROM "public"."Device" d
+WHERE s."allowedOutletId" IS NULL
+  AND s."allowedDeviceId" = d."id"
+  AND d."outletId" IS NOT NULL;
+
+-- Drop legacy indexes referencing deviceId
+DROP INDEX IF EXISTS "public"."Hold_merchantId_deviceId_idx";
+DROP INDEX IF EXISTS "public"."Receipt_merchantId_deviceId_idx";
+DROP INDEX IF EXISTS "public"."Transaction_merchantId_deviceId_idx";
+
+-- Drop foreign keys before removing columns
+ALTER TABLE "public"."Hold" DROP CONSTRAINT IF EXISTS "Hold_deviceId_fkey";
+ALTER TABLE "public"."Receipt" DROP CONSTRAINT IF EXISTS "Receipt_deviceId_fkey";
+ALTER TABLE "public"."Transaction" DROP CONSTRAINT IF EXISTS "Transaction_deviceId_fkey";
+ALTER TABLE "public"."CashierSession" DROP CONSTRAINT IF EXISTS "CashierSession_deviceId_fkey";
+
+-- Drop columns relying on deviceId/allowedDeviceId
+ALTER TABLE "public"."Hold" DROP COLUMN IF EXISTS "deviceId";
+ALTER TABLE "public"."Receipt" DROP COLUMN IF EXISTS "deviceId";
+ALTER TABLE "public"."Transaction" DROP COLUMN IF EXISTS "deviceId";
+ALTER TABLE "public"."CashierSession" DROP COLUMN IF EXISTS "deviceId";
+ALTER TABLE "public"."LedgerEntry" DROP COLUMN IF EXISTS "deviceId";
+ALTER TABLE "public"."EarnLot" DROP COLUMN IF EXISTS "deviceId";
+ALTER TABLE "public"."Staff" DROP COLUMN IF EXISTS "allowedDeviceId";
+
+-- Add FK for PushDevice -> Outlet to keep referential integrity
+ALTER TABLE "public"."PushDevice"
+    ADD CONSTRAINT "PushDevice_outletId_fkey"
+    FOREIGN KEY ("outletId") REFERENCES "public"."Outlet"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Finally drop Device table
+DROP TABLE IF EXISTS "public"."Device";

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -213,7 +213,6 @@ model Merchant {
   createdAt                   DateTime                     @default(now())
   Receipt                     Receipt[]
   outlets                     Outlet[]
-  devices                     Device[]
   staff                       Staff[]
   consents                    Consent[]
   telegramBot                 TelegramBot?
@@ -406,18 +405,15 @@ model Hold {
   qrJti         String?    @unique // <— НОВОЕ: один hold на один QR
   expiresAt     DateTime?
   outletId      String?
-  deviceId      String?
   staffId       String?
   createdAt     DateTime   @default(now())
 
   outlet Outlet? @relation(fields: [outletId], references: [id], onDelete: SetNull)
-  device Device? @relation(fields: [deviceId], references: [id], onDelete: SetNull)
   staff  Staff?  @relation(fields: [staffId], references: [id], onDelete: SetNull)
 
   @@index([customerId, status])
   @@index([merchantId, status])
   @@index([merchantId, outletId])
-  @@index([merchantId, deviceId])
   @@index([merchantId, staffId])
 }
 
@@ -436,17 +432,14 @@ model Receipt {
   earnApplied   Int      @default(0) // сколько начислили
   createdAt     DateTime @default(now())
   outletId      String?
-  deviceId      String?
   staffId       String?
 
   outlet Outlet? @relation(fields: [outletId], references: [id], onDelete: SetNull)
-  device Device? @relation(fields: [deviceId], references: [id], onDelete: SetNull)
   staff  Staff?  @relation(fields: [staffId], references: [id], onDelete: SetNull)
 
   @@unique([merchantId, orderId])
   @@index([merchantId, createdAt])
   @@index([merchantId, outletId])
-  @@index([merchantId, deviceId])
   @@index([merchantId, staffId])
 }
 
@@ -461,17 +454,14 @@ model Transaction {
   orderId    String?
   createdAt  DateTime @default(now())
   outletId   String?
-  deviceId   String?
   staffId    String?
 
   outlet Outlet? @relation(fields: [outletId], references: [id], onDelete: SetNull)
-  device Device? @relation(fields: [deviceId], references: [id], onDelete: SetNull)
   staff  Staff?  @relation(fields: [staffId], references: [id], onDelete: SetNull)
 
   @@index([customerId, createdAt])
   @@index([merchantId, createdAt])
   @@index([merchantId, outletId])
-  @@index([merchantId, deviceId])
   @@index([merchantId, staffId])
   @@index([merchantId, customerId, type, createdAt])
 }
@@ -537,10 +527,10 @@ model Outlet {
   updatedAt               DateTime @updatedAt
 
   // обратные связи
-  devices               Device[]
   holds                 Hold[]
   receipts              Receipt[]
   txns                  Transaction[]
+  pushDevices          PushDevice[]
   staffAccesses         StaffOutletAccess[]
   stocks                ProductStock[]
   schedules             OutletSchedule[]
@@ -574,28 +564,6 @@ model OutletSchedule {
   @@index([outletId])
 }
 
-model Device {
-  id           String     @id @default(cuid())
-  merchantId   String
-  merchant     Merchant   @relation(fields: [merchantId], references: [id])
-  outletId     String?
-  outlet       Outlet?    @relation(fields: [outletId], references: [id], onDelete: SetNull)
-  type         DeviceType
-  label        String?
-  lastSeenAt   DateTime?
-  bridgeSecret String?
-  createdAt    DateTime   @default(now())
-
-  // обратные связи
-  holds           Hold[]
-  receipts        Receipt[]
-  txns            Transaction[]
-  cashierSessions CashierSession[]
-
-  @@index([merchantId])
-  @@index([merchantId, outletId])
-}
-
 model Staff {
   id                         String            @id @default(cuid())
   merchantId                 String
@@ -608,7 +576,6 @@ model Staff {
   hash                       String?
   apiKeyHash                 String?
   allowedOutletId            String?
-  allowedDeviceId            String?
   createdAt                  DateTime          @default(now())
   updatedAt                  DateTime          @updatedAt
   // Profile & access
@@ -816,7 +783,6 @@ model CashierSession {
   merchantId  String
   staffId     String
   outletId    String?
-  deviceId    String?
   pinAccessId String?
   startedAt   DateTime  @default(now())
   endedAt     DateTime?
@@ -829,7 +795,6 @@ model CashierSession {
   merchant  Merchant           @relation(fields: [merchantId], references: [id])
   staff     Staff              @relation(fields: [staffId], references: [id])
   outlet    Outlet?            @relation(fields: [outletId], references: [id])
-  device    Device?            @relation(fields: [deviceId], references: [id])
   pinAccess StaffOutletAccess? @relation(fields: [pinAccessId], references: [id])
 
   @@index([merchantId, startedAt])
@@ -1029,7 +994,6 @@ model LedgerEntry {
   orderId    String?
   receiptId  String?
   outletId   String?
-  deviceId   String?
   staffId    String?
   meta       Json?
   createdAt  DateTime      @default(now())
@@ -1050,7 +1014,6 @@ model EarnLot {
   orderId        String?
   receiptId      String?
   outletId       String?
-  deviceId       String?
   staffId        String?
   status         String    @default("ACTIVE") // ACTIVE | PENDING
   createdAt      DateTime  @default(now())
@@ -1181,6 +1144,7 @@ model PushDevice {
   createdAt    DateTime  @default(now())
 
   customer Customer @relation(fields: [customerId], references: [id])
+  outlet   Outlet?  @relation(fields: [outletId], references: [id], onDelete: SetNull)
 
   @@unique([customerId, outletId])
   @@index([customerId])

--- a/api/prisma/seed-factories.cjs
+++ b/api/prisma/seed-factories.cjs
@@ -81,41 +81,7 @@ async function createOutlets(prisma, merchantId) {
     },
   });
 
-  const mainDevice = await prisma.device.upsert({
-    where: { id: 'device-main-pos' },
-    update: {
-      merchantId,
-      outletId: main.id,
-      type: 'SMART',
-      label: 'POS «Главный»',
-    },
-    create: {
-      id: 'device-main-pos',
-      merchantId,
-      outletId: main.id,
-      type: 'SMART',
-      label: 'POS «Главный»',
-    },
-  });
-
-  const kioskDevice = await prisma.device.upsert({
-    where: { id: 'device-kiosk-pos' },
-    update: {
-      merchantId,
-      outletId: kiosk.id,
-      type: 'PC_POS',
-      label: 'POS «Киоск»',
-    },
-    create: {
-      id: 'device-kiosk-pos',
-      merchantId,
-      outletId: kiosk.id,
-      type: 'PC_POS',
-      label: 'POS «Киоск»',
-    },
-  });
-
-  return { main, kiosk, devices: { main: mainDevice, kiosk: kioskDevice } };
+  return { main, kiosk };
 }
 
 async function createAccessGroups(prisma, merchantId, ownerId) {
@@ -1625,7 +1591,6 @@ async function createAnalytics(prisma, merchantId, staff, outlets, customers, se
         merchantId,
         staffId: staff.manager.id,
         outletId: outlets.main.id,
-        deviceId: outlets.devices?.main?.id || null,
         pinAccessId: 'soa-manager-main',
         startedAt: nowMinus({ hours: 5 }),
         endedAt: nowMinus({ hours: 4 }),
@@ -1638,7 +1603,6 @@ async function createAnalytics(prisma, merchantId, staff, outlets, customers, se
         merchantId,
         staffId: staff.cashier.id,
         outletId: outlets.main.id,
-        deviceId: outlets.devices?.main?.id || null,
         pinAccessId: 'soa-cashier-main',
         startedAt: nowMinus({ hours: 2 }),
         result: 'ACTIVE',

--- a/api/src/integrations/README.md
+++ b/api/src/integrations/README.md
@@ -19,7 +19,7 @@
 
 1. В админке откройте нужную торговую точку и задайте POS-тип (`PUT /merchants/{id}/outlets/{outletId}/pos`, поле `posType` = `PC_POS` или `SMART`).
 2. Выдайте `bridgeSecret` для точки: `POST /merchants/{id}/outlets/{outletId}/bridge-secret` (для ротации используйте `/bridge-secret/next`).
-3. При вызове `/loyalty/quote` и `/loyalty/commit` указывайте `merchantId`, `outletId`, `orderId` (поле `deviceId` остаётся для обратной совместимости, но новые клиенты должны переходить на `outletId`).
+3. При вызове `/loyalty/quote` и `/loyalty/commit` передавайте `merchantId`, `outletId`, `orderId` — `deviceId` более не поддерживается.
 3. Если включена опция `requireBridgeSig`, формируйте заголовок `X-Bridge-Signature`:
    - Сигнатура = `base64( HMAC-SHA256( secret, ts + '.' + body ) )`
    - Где `ts` — UNIX-время в секундах, `body` — JSON тела запроса без пробелов.

--- a/api/src/loyalty/loyalty.controller.ts
+++ b/api/src/loyalty/loyalty.controller.ts
@@ -248,9 +248,7 @@ export class LoyaltyController {
           secret = s?.bridgeSecret || null;
           alt = (s as any)?.bridgeSecretNext || null;
         }
-        const dtoForSig = { ...(dto as any) };
-        delete dtoForSig.deviceId;
-        const bodyForSig = JSON.stringify(dtoForSig);
+        const bodyForSig = JSON.stringify(dto);
         let ok = false;
         if (secret && verifyBridgeSigUtil(sig, bodyForSig, secret)) ok = true;
         else if (alt && verifyBridgeSigUtil(sig, bodyForSig, alt)) ok = true;

--- a/api/src/loyalty/loyalty.service.levels.spec.ts
+++ b/api/src/loyalty/loyalty.service.levels.spec.ts
@@ -27,7 +27,6 @@ function mkPrisma(overrides: any = {}) {
       // Customer earned total 600 within period -> Silver
       findMany: jest.fn(async () => ([ { amount: 300 }, { amount: 300 } ])),
     },
-    device: { findUnique: jest.fn(async () => null) },
     hold: { findUnique: jest.fn(async () => null), create: jest.fn(async (args: any) => ({ id: 'H1', ...args?.data })) },
     wallet: {
       findFirst: jest.fn(async () => null),

--- a/api/src/loyalty/loyalty.service.spec.ts
+++ b/api/src/loyalty/loyalty.service.spec.ts
@@ -34,7 +34,7 @@ describe('LoyaltyService.commit idempotency', () => {
     prisma.wallet.findFirst.mockResolvedValue({ id: 'W1', balance: 0, type: 'POINTS' });
     // emulate tx
     prisma.$transaction = jest.fn(async (fn: any) => {
-      const tx = mkPrisma({ receipt: { findUnique: jest.fn(), create: jest.fn(() => { const e: any = new Error('unique constraint'); throw e; }) }, wallet: { findUnique: jest.fn(() => ({ id: 'W1', balance: 0 })), update: jest.fn() }, transaction: { create: jest.fn() }, eventOutbox: { create: jest.fn() }, hold: { update: jest.fn() }, device: { update: jest.fn() } });
+      const tx = mkPrisma({ receipt: { findUnique: jest.fn(), create: jest.fn(() => { const e: any = new Error('unique constraint'); throw e; }) }, wallet: { findUnique: jest.fn(() => ({ id: 'W1', balance: 0 })), update: jest.fn() }, transaction: { create: jest.fn() }, eventOutbox: { create: jest.fn() }, hold: { update: jest.fn() } });
       // when create fails, service should try findUnique again
       tx.receipt.findUnique.mockResolvedValue({ id: 'R_EXIST', redeemApplied: 0, earnApplied: 10 });
       return fn(tx);

--- a/api/src/merchants/dto.ts
+++ b/api/src/merchants/dto.ts
@@ -154,8 +154,6 @@ export class UpdateStaffDto {
   @ApiPropertyOptional()
   @IsOptional() @IsString() allowedOutletId?: string;
   @ApiPropertyOptional()
-  @IsOptional() @IsString() allowedDeviceId?: string;
-  @ApiPropertyOptional()
   @IsOptional() @IsString() firstName?: string;
   @ApiPropertyOptional()
   @IsOptional() @IsString() lastName?: string;
@@ -231,7 +229,6 @@ export class StaffDto {
   @ApiProperty({ enum: StaffRole }) role!: keyof typeof StaffRole | string;
   @ApiProperty() status!: string;
   @ApiPropertyOptional() allowedOutletId?: string|null;
-  @ApiPropertyOptional() allowedDeviceId?: string|null;
   @ApiPropertyOptional() apiKeyHash?: string|null;
   @ApiProperty() createdAt!: Date;
 }

--- a/api/src/merchants/merchants.service.ts
+++ b/api/src/merchants/merchants.service.ts
@@ -543,7 +543,6 @@ export class MerchantsService {
     if (dto.role !== undefined) data.role = dto.role as any;
     if (dto.status !== undefined) data.status = dto.status;
     if (dto.allowedOutletId !== undefined) data.allowedOutletId = dto.allowedOutletId || null;
-    if (dto.allowedDeviceId !== undefined) data.allowedDeviceId = dto.allowedDeviceId || null;
     if (dto.firstName !== undefined) data.firstName = dto.firstName != null && String(dto.firstName).trim() ? String(dto.firstName).trim() : null;
     if (dto.lastName !== undefined) data.lastName = dto.lastName != null && String(dto.lastName).trim() ? String(dto.lastName).trim() : null;
     if (dto.position !== undefined) data.position = dto.position != null && String(dto.position).trim() ? String(dto.position).trim() : null;

--- a/api/src/portal/services/__tests__/operations-log.service.spec.ts
+++ b/api/src/portal/services/__tests__/operations-log.service.spec.ts
@@ -25,8 +25,7 @@ describe('OperationsLogService', () => {
           merchantId: 'm1',
           customer: { id: 'c1', name: 'Иван', phone: '+79990001122' },
           staff: { id: 's1', firstName: 'Анна', lastName: 'Смирнова', status: 'ACTIVE' },
-          outlet: { id: 'o1', name: 'Главный зал' },
-          device: { id: 'd1', type: 'SMART', label: 'Касса 1' },
+          outlet: { id: 'o1', name: 'Главный зал', posType: 'SMART', code: 'POS-1' },
           redeemApplied: 100,
           earnApplied: 50,
           total: 1200,
@@ -46,7 +45,7 @@ describe('OperationsLogService', () => {
       rating: 4,
       redeem: { amount: 100 },
       earn: { amount: 50 },
-      carrier: { type: 'SMART', label: 'Касса 1' },
+      carrier: { type: 'SMART', label: 'Главный зал', code: 'POS-1' },
     });
   });
 });

--- a/api/src/portal/services/operations-log.service.ts
+++ b/api/src/portal/services/operations-log.service.ts
@@ -94,7 +94,6 @@ export class OperationsLogService {
           customer: true,
           staff: true,
           outlet: true,
-          device: true,
         },
       }),
     ]);
@@ -114,7 +113,6 @@ export class OperationsLogService {
         customer: true,
         staff: true,
         outlet: true,
-        device: true,
       },
     });
 
@@ -172,7 +170,7 @@ export class OperationsLogService {
     return map;
   }
 
-  private mapReceipt(receipt: Prisma.ReceiptGetPayload<{ include: { customer: true; staff: true; outlet: true; device: true } }>, rating: number | null): OperationsLogItemDto {
+  private mapReceipt(receipt: Prisma.ReceiptGetPayload<{ include: { customer: true; staff: true; outlet: true } }>, rating: number | null): OperationsLogItemDto {
     const staffName = receipt.staff
       ? [receipt.staff.firstName, receipt.staff.lastName].filter(Boolean).join(' ').trim() || receipt.staff.id
       : null;
@@ -205,12 +203,13 @@ export class OperationsLogService {
     };
   }
 
-  private buildCarrier(receipt: Prisma.ReceiptGetPayload<{ include: { customer: true; device: true } }>): OperationsLogItemDto['carrier'] {
-    if (receipt.device) {
+  private buildCarrier(receipt: Prisma.ReceiptGetPayload<{ include: { customer: true; outlet: true } }>): OperationsLogItemDto['carrier'] {
+    if (receipt.outlet) {
+      const posType = (receipt.outlet.posType as string | null) ?? null;
       return {
-        type: receipt.device.type,
-        code: receipt.device.id,
-        label: receipt.device.label,
+        type: posType ?? 'OUTLET',
+        code: receipt.outlet.code ?? receipt.outlet.externalId ?? receipt.outlet.id,
+        label: receipt.outlet.name ?? null,
       };
     }
     if (receipt.customer.phone) {

--- a/api/test/combo.levels.promocode.promo.commit.cap.e2e-spec.ts
+++ b/api/test/combo.levels.promocode.promo.commit.cap.e2e-spec.ts
@@ -37,7 +37,6 @@ describe('Combo: Promo+Rules+Levels with Commit then repeat Quote (per-order cap
       findMany: async (_args: any) => [{ id: 'T1', merchantId: state.settings.merchantId, customerId: 'C-Combo', type: 'EARN', amount: 120, createdAt: new Date() }],
       create: async (_args: any) => ({ id: 'T-REDEEM' })
     },
-    device: { findUnique: async ()=>null, update: async ()=>({}) },
     wallet: {
       findFirst: async (_args: any) => ({ id: 'W1', balance: state.walletBal }),
       findUnique: async (_args: any) => ({ id: 'W1', balance: state.walletBal }),
@@ -73,7 +72,6 @@ describe('Combo: Promo+Rules+Levels with Commit then repeat Quote (per-order cap
       },
       eventOutbox: { create: async (_args: any) => ({}) },
       transaction: { create: async (_args: any) => ({ id: 'T-REDEEM' }) },
-      device: { update: async ()=>({}) },
     }),
   };
 

--- a/api/test/levels.bonus.e2e-spec.ts
+++ b/api/test/levels.bonus.e2e-spec.ts
@@ -28,7 +28,6 @@ describe('Levels bonuses applied in quote (e2e)', () => {
       findMany: async (args: any) => state.txns.filter(t => t.merchantId === args.where.merchantId && t.customerId === args.where.customerId && (!args.where.type || t.type === args.where.type) && (!args.where.createdAt?.gte || t.createdAt >= args.where.createdAt.gte)),
       count: async (args: any) => state.txns.filter(t => t.merchantId === args.where.merchantId && t.customerId === args.where.customerId && (!args.where.createdAt?.gte || t.createdAt >= args.where.createdAt.gte)).length,
     },
-    device: { findUnique: async () => null },
     hold: { create: async (args: any) => ({ id: 'H1', ...args.data }) },
     wallet: {
       findFirst: async (_args: any) => ({ id: 'W1', balance: 2000, type: 'POINTS' }),

--- a/api/test/levels.commit.e2e-spec.ts
+++ b/api/test/levels.commit.e2e-spec.ts
@@ -32,7 +32,6 @@ describe('Levels bonuses with commit (e2e)', () => {
       count: async (args: any) => state.txns.filter(t => t.merchantId === args.where.merchantId && t.customerId === args.where.customerId && (!args.where.createdAt?.gte || t.createdAt >= args.where.createdAt.gte)).length,
       create: async (args: any) => { state.txns.push({ merchantId: args.data.merchantId, customerId: args.data.customerId, type: args.data.type, amount: args.data.amount, createdAt: new Date() } as any); return { id: 'T1', ...args.data }; },
     },
-    device: { findUnique: async () => null },
     hold: {
       findUnique: async (args: any) => state.holds.find(h => h.id === args.where.id) || null,
       create: async (args: any) => { const h = { id: 'H1', ...args.data }; state.holds.push(h); return h; },

--- a/api/test/quote.sanitization.e2e-spec.ts
+++ b/api/test/quote.sanitization.e2e-spec.ts
@@ -30,7 +30,6 @@ describe('Quote sanitization (e2e)', () => {
     },
     eventOutbox: { create: async (_args: any) => ({}) },
     transaction: { findFirst: async ()=>null, findMany: async ()=>[], create: async ()=>({ id:'T1'}) },
-    device: { findUnique: async ()=>null },
     $transaction: async (fn: (tx: any)=>Promise<any>) => fn({
       merchant: { upsert: async ()=>({}) },
       wallet: {
@@ -42,7 +41,6 @@ describe('Quote sanitization (e2e)', () => {
       hold: { create: async (args: any) => ({ ...args.data, id: 'H1' }) },
       eventOutbox: { create: async (_args: any) => ({}) },
       transaction: { create: async ()=>({ id:'T1'}) },
-      device: { update: async ()=>({}) },
     }),
   };
 

--- a/api/test/redeem.concurrent.order.commit.e2e-spec.ts
+++ b/api/test/redeem.concurrent.order.commit.e2e-spec.ts
@@ -40,7 +40,6 @@ describe('REDEEM concurrent commit per-order idempotency (e2e)', () => {
         create: async (args: any) => { const r = { id: 'R1', ...args.data }; state.receipts.push(r); return r; },
       },
       eventOutbox: { create: async ()=>({}) },
-      device: { update: async ()=>({}) },
     }),
     merchant: { upsert: async ()=>({}) },
     merchantSettings: { findUnique: async (args: any) => ({ merchantId: args.where.merchantId, earnBps: 500, redeemLimitBps: 5000, updatedAt: new Date(), rulesJson: null }) },
@@ -61,7 +60,6 @@ describe('REDEEM concurrent commit per-order idempotency (e2e)', () => {
       findUnique: async (args: any) => state.receipts.find(r=>r.merchantId===args.where.merchantId_orderId.merchantId && r.orderId===args.where.merchantId_orderId.orderId) || null,
       create: async (args: any) => { const r = { id: 'R1', ...args.data }; state.receipts.push(r); return r; },
     },
-    device: { findUnique: async ()=>null },
     eventOutbox: { create: async ()=>({}) },
   };
 

--- a/plan.md
+++ b/plan.md
@@ -19,6 +19,7 @@
   - [x] LoyaltyController окончательно отказался от `deviceId`: подпись Bridge/hold кешируются только по `outletId`, публичные DTO и роуты очищены.
 - [x] LoyaltyService: расчёт/commit/refund и outbox работают только с `outletId`, записи `deviceId` прекращены.
 - [x] Guard'ы: троттлер, антифрод и кассир работают без `deviceId`, опираются на `outletId` и роли сотрудников.
+- [x] Device-модель убрана окончательно: миграция добрала `bridgeSecret`/`lastSeen`, ограничение сотрудников переведено на точки, Prisma очищена от `deviceId`.
 
 ## Батчи внедрения (план)
 


### PR DESCRIPTION
## Summary
- drop the Device model from the Prisma schema, remove `deviceId`/`allowedDeviceId`, and link push devices back to outlets
- add a cleanup migration that backfills bridge secrets/last seen data, migrates staff restrictions to outlets, and drops the Device table
- update seeds, Evotor integration, portal operations log, plan, and docs to reflect outlet-based flows only

## Testing
- `pnpm --filter api exec prisma generate` *(fails: Prisma engines download returns 403)*
- `pnpm --filter api test` *(fails: `prisma generate` pretest cannot download engines)*

------
https://chatgpt.com/codex/tasks/task_e_68dca07cb3f483249966c85ccc6c9dda