### PR TITLE
Fix SMS cleanup in migration

### DIFF
--- a/api/prisma/migrations/20251020131500_remove_sms_channel/migration.sql
+++ b/api/prisma/migrations/20251020131500_remove_sms_channel/migration.sql
@@ -1,7 +1,7 @@
 -- Remove legacy SMS channel data before narrowing CommunicationChannel enum
-DELETE FROM "public"."CommunicationTaskRecipient" WHERE "channel" = 'SMS';
-DELETE FROM "public"."CommunicationTask" WHERE "channel" = 'SMS';
-DELETE FROM "public"."CommunicationTemplate" WHERE "channel" = 'SMS';
+DELETE FROM "public"."CommunicationTaskRecipient" WHERE "channel"::text = 'SMS';
+DELETE FROM "public"."CommunicationTask" WHERE "channel"::text = 'SMS';
+DELETE FROM "public"."CommunicationTemplate" WHERE "channel"::text = 'SMS';
 
 -- Recreate enum without SMS value
 ALTER TYPE "public"."CommunicationChannel" RENAME TO "CommunicationChannel_old";


### PR DESCRIPTION
## Summary
- cast channel values to text before comparing with 'SMS' in the removal migration

## Testing
- pnpm prisma migrate dev *(fails: Prisma engine checksum download returns 403 in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd0646210832489a16a7c053a74c5