### PR TITLE
Fix CashierGuard bridge signature handling for loyalty endpoints

### DIFF
--- a/api/src/guards/cashier.guard.ts
+++ b/api/src/guards/cashier.guard.ts
@@ -1,10 +1,138 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import * as crypto from 'crypto';
+import { verifyBridgeSignature } from '../loyalty/bridge.util';
 
 @Injectable()
 export class CashierGuard implements CanActivate {
   constructor(private prisma: PrismaService) {}
+
+  private async getBridgeSecrets(
+    merchantId: string,
+    outletId: string | null,
+    settingsHint?: any,
+  ): Promise<{ primary: string | null; secondary: string | null }> {
+    let primary: string | null = null;
+    let secondary: string | null = null;
+
+    if (outletId) {
+      try {
+        const outlet = await this.prisma.outlet.findFirst({
+          where: { id: outletId, merchantId },
+          select: { bridgeSecret: true, bridgeSecretNext: true },
+        });
+        if (outlet) {
+          primary = outlet.bridgeSecret ?? null;
+          secondary = outlet.bridgeSecretNext ?? null;
+        }
+      } catch {}
+    }
+
+    let settings = settingsHint;
+    if (!settings) {
+      try {
+        settings = await this.prisma.merchantSettings.findUnique({ where: { merchantId } });
+      } catch {}
+    }
+
+    if (!primary && settings?.bridgeSecret) primary = settings.bridgeSecret;
+    if (!secondary && (settings as any)?.bridgeSecretNext)
+      secondary = (settings as any).bridgeSecretNext;
+
+    return { primary, secondary };
+  }
+
+  private verifyWithSecrets(sig: string, payload: string, primary: string | null, secondary: string | null): boolean {
+    if (!sig || !payload) return false;
+    if (primary && verifyBridgeSignature(sig, payload, primary)) return true;
+    if (secondary && verifyBridgeSignature(sig, payload, secondary)) return true;
+    return false;
+  }
+
+  private async hasValidBridgeSignature(
+    path: string,
+    req: any,
+    merchantIdHint?: string,
+    settingsHint?: any,
+  ): Promise<boolean> {
+    const sig = (req?.headers?.['x-bridge-signature'] as string | undefined) || '';
+    if (!sig) return false;
+
+    const body = req?.body || {};
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+    let merchantId: string | undefined = merchantIdHint || undefined;
+    let outletId: string | null = null;
+    let payload: string | null = null;
+
+    if (normalizedPath === '/loyalty/quote') {
+      if (!merchantId) return false;
+      outletId = body?.outletId ?? null;
+      payload = JSON.stringify(body);
+    } else if (normalizedPath === '/loyalty/commit') {
+      const holdId: string | undefined = body?.holdId;
+      if (!holdId) return false;
+      let hold: { merchantId: string; outletId: string | null } | null = null;
+      try {
+        hold = await this.prisma.hold.findUnique({
+          where: { id: holdId },
+          select: { merchantId: true, outletId: true },
+        });
+      } catch {}
+      merchantId = merchantId || hold?.merchantId || undefined;
+      if (!merchantId) return false;
+      outletId = hold?.outletId ?? null;
+      payload = JSON.stringify({
+        merchantId,
+        holdId,
+        orderId: body?.orderId,
+        receiptNumber: body?.receiptNumber ?? undefined,
+      });
+    } else if (normalizedPath === '/loyalty/refund') {
+      if (!merchantId) return false;
+      try {
+        const receipt = await this.prisma.receipt.findUnique({
+          where: { merchantId_orderId: { merchantId, orderId: body?.orderId } },
+          select: { outletId: true },
+        });
+        outletId = receipt?.outletId ?? null;
+      } catch {}
+      payload = JSON.stringify({
+        merchantId,
+        orderId: body?.orderId,
+        refundTotal: body?.refundTotal,
+        refundEligibleTotal: body?.refundEligibleTotal ?? undefined,
+      });
+    } else if (normalizedPath === '/loyalty/cancel') {
+      const holdId: string | undefined = body?.holdId;
+      if (!holdId) return false;
+      let hold: { merchantId: string; outletId: string | null } | null = null;
+      try {
+        hold = await this.prisma.hold.findUnique({
+          where: { id: holdId },
+          select: { merchantId: true, outletId: true },
+        });
+      } catch {}
+      merchantId = merchantId || hold?.merchantId || undefined;
+      if (!merchantId) return false;
+      outletId = hold?.outletId ?? null;
+      payload = JSON.stringify({ merchantId, holdId });
+    } else {
+      return false;
+    }
+
+    if (!payload) return false;
+
+    const { primary, secondary } = await this.getBridgeSecrets(
+      merchantId,
+      outletId,
+      merchantIdHint && merchantIdHint === merchantId ? settingsHint : undefined,
+    );
+
+    if (!primary && !secondary) return false;
+
+    return this.verifyWithSecrets(sig, payload, primary, secondary);
+  }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const req = context.switchToHttp().getRequest() as any;
@@ -31,14 +159,30 @@ export class CashierGuard implements CanActivate {
 
     // Проверяем требование ключа на уровне мерчанта
     let requireStaffKey = false;
+    let merchantSettings: any = null;
     try {
       const merchantId = body?.merchantId || req?.params?.merchantId || req?.query?.merchantId;
       if (merchantId) {
-        const s = await this.prisma.merchantSettings.findUnique({ where: { merchantId } });
-        requireStaffKey = Boolean(s?.requireStaffKey);
+        merchantSettings = await this.prisma.merchantSettings.findUnique({ where: { merchantId } });
+        requireStaffKey = Boolean(merchantSettings?.requireStaffKey);
       }
     } catch {}
-    if (!key) return !requireStaffKey; // если требуется — блокируем, иначе пропускаем
+    if (!key) {
+      if (!requireStaffKey) return true;
+      if (req?.teleauth?.customerId) return true;
+      const pathForCheck = path || '';
+      if (
+        await this.hasValidBridgeSignature(
+          pathForCheck,
+          req,
+          body?.merchantId || req?.params?.merchantId || req?.query?.merchantId,
+          merchantSettings,
+        )
+      ) {
+        return true;
+      }
+      return false;
+    }
     const hash = crypto.createHash('sha256').update(key, 'utf8').digest('hex');
     const merchantIdForStaff = body?.merchantId || req?.params?.merchantId || req?.query?.merchantId;
     const staff = await this.prisma.staff.findFirst({

--- a/plan.md
+++ b/plan.md
@@ -314,6 +314,7 @@
   - Cashier UI: реализовать экран кассира (login 9‑значный пароль мерчанта → ввод PIN сотрудника по точке) и привязку к `X-Staff-Key`.
   - Promocodes (points): расширить обработку в `LoyaltyService.commit()` для начислений по промокоду (POINTS) — idempotent по `orderId`, структурные логи/метрики; e2e.
     - [x] Централизовать бизнес-логику промокодов в `PromoCodesService`, перевести портал/loyalty-контроллеры и метрики на единый слой.
+    - [x] CashierGuard учитывает bridge signature и teleauth при `requireStaffKey`, чтобы `quote/commit/refund/cancel` не падали с 403.
   - E2E: добавить кейс earn по промокоду POINTS (issue → quote/commit с promoCode → проверка баланса/транзакций).
 
 ## Волна 3 — Завершена (2025-09-15)


### PR DESCRIPTION
## Summary
- allow the cashier guard to honor bridge signatures or teleauth when requireStaffKey is enabled so loyalty quote/commit/refund stay accessible
- document the fix in plan.md for the loyalty wave checklist

## Testing
- PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm -C api test --filter cashier.guard --runInBand *(fails: Prisma engine download returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de036aa88883248db1f209cf86aafc