### PR TITLE
feat: refresh miniapp QR layout

### DIFF
--- a/miniapp/app/qr/page.module.css
+++ b/miniapp/app/qr/page.module.css
@@ -44,7 +44,7 @@
   position: relative;
   width: 240px;
   height: 240px;
-  padding: 16px;
+  padding: clamp(12px, 3vw, 16px);
   border-radius: 22px;
   background: rgba(255, 255, 255, 0.94);
   display: flex;
@@ -71,9 +71,10 @@
 
 .qrFooter {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+  gap: 12px;
 }
 
 .refreshButton {
@@ -104,40 +105,41 @@
 }
 
 .ttlHint {
-  font-size: 13px;
-  opacity: 0.85;
+  font-size: 14px;
+  font-weight: 600;
+  opacity: 0.9;
 }
 
 .infoGrid {
   display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: clamp(12px, 3vw, 16px);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .infoCard {
   background: #ffffff;
   border-radius: 24px;
-  padding: 18px 20px;
+  padding: clamp(14px, 3.4vw, 20px);
   box-shadow: 0 20px 46px rgba(130, 134, 255, 0.2);
   display: grid;
   gap: 6px;
 }
 
 .infoLabel {
-  font-size: 14px;
+  font-size: clamp(12px, 3.5vw, 14px);
   font-weight: 600;
   color: #5c5796;
   letter-spacing: 0.02em;
 }
 
 .infoValue {
-  font-size: 26px;
+  font-size: clamp(20px, 6vw, 26px);
   font-weight: 700;
   color: #1f1f33;
 }
 
 .infoCaption {
-  font-size: 13px;
+  font-size: clamp(11px, 3.2vw, 13px);
   color: #8b86c2;
 }
 
@@ -187,14 +189,15 @@
 }
 
 @media (max-width: 420px) {
-  .qrWrapper {
-    width: 200px;
-    height: 200px;
-    padding: 12px;
+  .qrSection {
+    padding: 24px 18px;
   }
 
-  .qrPlaceholder {
-    width: 168px;
-    height: 168px;
+  .qrFooter {
+    gap: 10px;
+  }
+
+  .refreshButton {
+    padding: 10px 22px;
   }
 }


### PR DESCRIPTION
## Summary
- update the QR page to show a concise timer next to the refresh button and resize the QR canvas responsively
- rename the balance and loyalty captions, remove the cashback card, and display the cashback value within the level block
- tweak styles so the balance and level cards stay side by side across screen sizes

## Testing
- pnpm --filter miniapp dev

------
https://chatgpt.com/codex/tasks/task_e_68e0ec49c4e48324922e59763109c04b