### PR TITLE
feat: unify loyalty transaction calculation

### DIFF
--- a/api/src/integrations/integrations.module.ts
+++ b/api/src/integrations/integrations.module.ts
@@ -10,9 +10,10 @@ import { ModulKassaController } from './modulkassa/modulkassa.controller';
 import { PosterService } from './poster/poster.service';
 import { PosterController } from './poster/poster.controller';
 import { OAuthGuard } from '../guards/oauth.guard';
+import { LoyaltyModule } from '../loyalty/loyalty.module';
 
 @Module({
-  imports: [PrismaModule, ConfigModule],
+  imports: [PrismaModule, ConfigModule, LoyaltyModule],
   controllers: [AtolController, EvotorController, ModulKassaController, PosterController],
   providers: [AtolService, EvotorService, ModulKassaService, PosterService, OAuthGuard],
   exports: [AtolService, EvotorService, ModulKassaService, PosterService],

--- a/api/src/loyalty/dto.ts
+++ b/api/src/loyalty/dto.ts
@@ -79,6 +79,7 @@ export class QuoteRedeemRespDto {
   @ApiProperty() finalPayable!: number;
   @ApiPropertyOptional() holdId?: string;
   @ApiPropertyOptional() message?: string;
+  @ApiPropertyOptional({ type: 'object', additionalProperties: true }) meta?: Record<string, any>;
 }
 
 export class QuoteEarnRespDto {
@@ -86,6 +87,7 @@ export class QuoteEarnRespDto {
   @ApiProperty() pointsToEarn!: number;
   @ApiPropertyOptional() holdId?: string;
   @ApiPropertyOptional() message?: string;
+  @ApiPropertyOptional({ type: 'object', additionalProperties: true }) meta?: Record<string, any>;
 }
 
 export class CommitRespDto {

--- a/cashier/src/app/page.tsx
+++ b/cashier/src/app/page.tsx
@@ -11,12 +11,14 @@ type QuoteRedeemResp = {
   finalPayable?: number;
   holdId?: string;
   message?: string;
+  meta?: Record<string, any>;
 };
 type QuoteEarnResp = {
   canEarn?: boolean;
   pointsToEarn?: number;
   holdId?: string;
   message?: string;
+  meta?: Record<string, any>;
 };
 type Txn = { id: string; type: 'EARN'|'REDEEM'|'REFUND'|'ADJUST'; amount: number; orderId?: string|null; createdAt: string; outletId?: string|null; outletPosType?: string|null; outletLastSeenAt?: string|null };
 


### PR DESCRIPTION
## Summary
- add a reusable transaction preview helper so loyalty quotes reuse level-aware rates and metadata
- surface the computed metadata in quote DTOs/cashier types and attach it to responses
- update the Evotor integration to rely on the shared helper and extend loyalty tests

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm -C api test -- --runTestsByPath src/loyalty/loyalty.service.levels.spec.ts` *(fails: Prisma engine download blocked in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68e24c11b0708324b690e3348481557f